### PR TITLE
fix: Require Node 14 only

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
     "prepublishOnly": "yarn build"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=14.14"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "module": "commonjs",
-    "target": "ES2021",
+    "target": "ES2020",
     "lib": [
-      "ES2021"
+      "ES2020"
     ],
     "sourceMap": false,
     "strict": true,


### PR DESCRIPTION
In order to get https://github.com/electron/windows-installer/pull/501 over the hump, I'll need `@electron/windows-sign` to install fine on Node 14. Turns out, we don't really need Node 16, so I'm just downgrading our requirements here.

This is a non-breaking change.