### PR TITLE
feat: support skipping SHA1 signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ description = "My content"
 website = "https://mywebsite.com"
 // If enabled, attempt to sign .js JavaScript files. Disabled by default
 signJavaScript = true
+// If unspecified, both sha1 and sha256 signatures will be appended. Will be passed to signtool.exe as the /fd option.
+hash = "sha256" 
 ```
 
 ## With a custom signtool.exe or custom parameters

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ website = "https://mywebsite.com"
 // If enabled, attempt to sign .js JavaScript files. Disabled by default
 signJavaScript = true
 // If unspecified, both sha1 and sha256 signatures will be appended. Will be passed to signtool.exe as the /fd option.
-hash = "sha256" 
+hashes = ["sha256"]
 ```
 
 ## With a custom signtool.exe or custom parameters

--- a/src/sign-with-signtool.ts
+++ b/src/sign-with-signtool.ts
@@ -119,6 +119,10 @@ export async function signWithSignTool(options: InternalSignOptions) {
     website
   };
 
-  await execute({ ...internalOptions, hash: HASHES.sha1 });
-  await execute({ ...internalOptions, hash: HASHES.sha256, appendSignature: true });
+  if (options.hash == null || options.hash === HASHES.sha1) {
+    await execute({ ...internalOptions, hash: HASHES.sha1 });
+  }
+  if (options.hash == null || options.hash === HASHES.sha256) {
+    await execute({ ...internalOptions, hash: HASHES.sha256, appendSignature: true });
+  }
 }

--- a/src/sign-with-signtool.ts
+++ b/src/sign-with-signtool.ts
@@ -119,10 +119,15 @@ export async function signWithSignTool(options: InternalSignOptions) {
     website
   };
 
-  if (options.hash == null || options.hash === HASHES.sha1) {
+  const hashes =
+    options.hashes == null || options.hashes.length === 0
+      ? [HASHES.sha1, HASHES.sha256]
+      : options.hashes;
+
+  if (hashes.includes(HASHES.sha1)) {
     await execute({ ...internalOptions, hash: HASHES.sha1 });
   }
-  if (options.hash == null || options.hash === HASHES.sha256) {
+  if (hashes.includes(HASHES.sha256)) {
     await execute({ ...internalOptions, hash: HASHES.sha256, appendSignature: true });
   }
 }

--- a/src/sign-with-signtool.ts
+++ b/src/sign-with-signtool.ts
@@ -109,6 +109,7 @@ export async function signWithSignTool(options: InternalSignOptions) {
   }
 
   const internalOptions = {
+    appendSignature: false,
     ...options,
     certificateFile,
     certificatePassword,
@@ -126,8 +127,10 @@ export async function signWithSignTool(options: InternalSignOptions) {
 
   if (hashes.includes(HASHES.sha1)) {
     await execute({ ...internalOptions, hash: HASHES.sha1 });
+    // If we signed with SHA1, we need to append the SHA256 signature:
+    internalOptions.appendSignature = true
   }
   if (hashes.includes(HASHES.sha256)) {
-    await execute({ ...internalOptions, hash: HASHES.sha256, appendSignature: true });
+    await execute({ ...internalOptions, hash: HASHES.sha256 });
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,7 +25,7 @@ export interface SignToolOptions extends OptionalSignToolOptions, OptionalHookOp
 
 export interface InternalSignOptions extends SignOptionsForFiles {}
 
-export interface InternalSignToolOptions extends OptionalSignToolOptions, OptionalHookOptions {
+export interface InternalSignToolOptions extends OptionalSignToolOptions, Omit<OptionalHookOptions, 'hashes'> {
   certificateFile?: string;
   certificatePassword?: string;
   signToolPath: string;
@@ -60,8 +60,8 @@ export interface OptionalSignToolOptions {
   automaticallySelectCertificate?: boolean;
   // Should we sign JavaScript files? Defaults to false
   signJavaScript?: boolean
-  // Which hash algorithm to use. If unspecified, sign twice with sha1 and sha256
-  hash?: HASHES;
+  // Which hash algorithm to use. If unspecified the default is ["sha1", "sha256"]
+  hashes?: HASHES[];
 }
 
 export type HookFunction = (fileToSign: string) => void | Promise<void>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -60,6 +60,8 @@ export interface OptionalSignToolOptions {
   automaticallySelectCertificate?: boolean;
   // Should we sign JavaScript files? Defaults to false
   signJavaScript?: boolean
+  // Which hash algorithm to use. If unspecified, sign twice with sha1 and sha256
+  hash?: HASHES;
 }
 
 export type HookFunction = (fileToSign: string) => void | Promise<void>;


### PR DESCRIPTION
Howdy! Thanks for this package!

Codesigning for my project is quite slow due to the number of .DLLs I need to include. It seems that SHA1 signatures are ignored ever since WIndows 7, and SHA256 is recommended by Microsoft.

Have you considered allowing consumers skip SHA1 signatures?

This patch allows an optional `hash` to be specified in the options array. It halves my signing time (which takes upwards of 10 minutes otherwise).

Feel free to tweak to taste. I tried to maintain consistency with existing code.

(BTW, if you switched your descriptive comments in your interfaces to jsdoc (use `/** message */` instead of `// message`) your consumers get to see those comments inline).