### PR TITLE
fix(docs): clean up types and create API documentation website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 yarn-error.log
 
 tmp
+
+docs

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
   "trailingComma": "all",
   "tabWidth": 2,
   "printWidth": 100,
-  "parser": "typescript"
+  "parser": "typescript",
+  "singleQuote": true
 }

--- a/package.json
+++ b/package.json
@@ -50,10 +50,12 @@
     "globstar": "^1.0.0",
     "standard": "^17.1.0",
     "tsx": "^3.14.0",
+    "typedoc": "~0.25.13",
     "typescript": "^5.2.2"
   },
   "scripts": {
     "build": "tsc && tsc -p tsconfig.esm.json",
+    "docs": "npx typedoc",
     "lint": "eslint --ext .ts,.js src bin test",
     "test:loader": "globstar -- node --loader tsx --test \"test/**/*.spec.ts\"",
     "test": "globstar -- node --import tsx --test \"test/**/*.spec.ts\"",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,25 @@
 import { sign } from './sign';
-import { createSeaSignTool } from './sea';
-import { OptionalHookOptions, OptionalSignToolOptions, SignOptions, SignToolOptions } from './types';
+import { createSeaSignTool, SeaOptions, InternalSeaOptions } from './sea';
+import {
+  HookFunction,
+  OptionalHookOptions,
+  OptionalSignToolOptions,
+  SignOptions,
+  SignToolOptions,
+  SignOptionsForDirectory,
+  SignOptionsForFiles
+} from './types';
 
-export { sign, SignOptions, SignToolOptions, OptionalSignToolOptions, OptionalHookOptions, createSeaSignTool };
+export {
+  sign,
+  SignOptions,
+  SignToolOptions,
+  HookFunction,
+  OptionalSignToolOptions,
+  OptionalHookOptions,
+  createSeaSignTool,
+  SeaOptions,
+  InternalSeaOptions,
+  SignOptionsForDirectory,
+  SignOptionsForFiles
+};

--- a/src/sea.ts
+++ b/src/sea.ts
@@ -8,19 +8,43 @@ import { spawnPromise } from './spawn';
 import { log } from './utils/log';
 import { SignToolOptions } from './types';
 
-interface SeaOptions {
-  // Full path to the sea. Needs to end with .exe
-  path: string
-  // Optional: A binary to use. Will use the current executable
-  // (process.execPath) by default.
+/**
+ * Options for signing with a Node.js single executable application.
+ *
+ * @category Single executable applications
+ */
+export interface SeaOptions {
+  /**
+   * Full path to the Node.js single executable application. Needs to end with `.exe`.
+   */
+  path: string;
+  /**
+   * A binary to use. Will use the current executable (process.execPath) by default.
+   *
+   * @defaultValue The Node.js {@link https://nodejs.org/api/process.html#processexecpath | `process.execPath`}
+   */
   bin?: string;
-  // Sign options
-  windowsSign: SignToolOptions
+  /**
+   * Options to pass to SignTool.
+   */
+  windowsSign: SignToolOptions;
 }
 
-interface InternalSeaOptions extends Required<SeaOptions> {
-  dir: string
-  filename: string
+/**
+ * This interface represents {@link SeaOptions} with all optional properties
+ * inferred by `@electron/windows-sign` if not passed in by the user.
+ *
+ * @category Single executable applications
+ */
+export interface InternalSeaOptions extends Required<SeaOptions> {
+  /**
+   * Directory of the Node.js single executable application.
+   */
+  dir: string;
+  /**
+   * File name of the Node.js single executable application.
+   */
+  filename: string;
 }
 
 /**
@@ -104,6 +128,8 @@ sign({ ...options, files })
  * This is useful with other tooling that _always_ calls
  * a signtool.exe to sign. Some of those tools cannot be
  * easily configured, but we _can_ override their signtool.exe.
+ *
+ * @category Single executable applications
  */
 export async function createSeaSignTool(options: Partial<SeaOptions> = {}): Promise<InternalSeaOptions> {
   checkCompatibility();

--- a/src/sign-with-hook.ts
+++ b/src/sign-with-hook.ts
@@ -32,7 +32,6 @@ function getHookFunction(options: InternalHookOptions): HookFunction {
  * Sign with a hook function, basically letting everyone
  * write completely custom sign logic
  *
- * @export
  * @param {InternalSignOptions} options
  */
 export async function signWithHook(options: InternalSignOptions) {

--- a/src/sign.ts
+++ b/src/sign.ts
@@ -13,6 +13,8 @@ import { booleanFromEnv } from './utils/parse-env';
  *
  * @param options
  * @returns {Promise<void>}
+ *
+ * @category Sign
  */
 export async function sign(options: SignOptions) {
   const signJavaScript = options.signJavaScript || booleanFromEnv('WINDOWS_SIGN_JAVASCRIPT');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,33 +1,53 @@
-// SHA-1 has been deprecated on Windows since 2016. We'll still dualsign.
-// https://social.technet.microsoft.com/wiki/contents/articles/32288.windows-enforcement-of-sha1-certificates.aspx#Post-February_TwentySeventeen_Plan
+/**
+ * SHA-1 has been deprecated on Windows since 2016. We'll still dualsign.
+ * https://social.technet.microsoft.com/wiki/contents/articles/32288.windows-enforcement-of-sha1-certificates.aspx#Post-February_TwentySeventeen_Plan
+ */
 export const enum HASHES {
   sha1 = 'sha1',
   sha256 = 'sha256',
 }
 
-export type SignOptions = SignOptionsForDirectory | SignOptionsForFiles
+/**
+ * Signing can be either by specifying a directory of files to sign.
+ *
+ * @category Sign
+ */
+export type SignOptions = SignOptionsForDirectory | SignOptionsForFiles;
 
+/**
+ * Options for signing by passing a path to a directory to be codesigned.
+ *
+ * @category Sign
+ */
 export interface SignOptionsForDirectory extends SignToolOptions {
-  // Path to the application directory. We will scan this
-  // directory for any .dll, .exe, .msi, or .node files and
-  // codesign them with signtool.exe
+  /**
+   * Path to the application directory. We will scan this
+   * directory for any `.dll`, `.exe`, `.msi`, or `.node` files and
+   * codesign them with `signtool.exe`.
+   */
   appDirectory: string;
 }
 
+/**
+ * Options for signing by passing an array of files to be codesigned.
+ *
+ * @category Sign
+ */
 export interface SignOptionsForFiles extends SignToolOptions {
-  // Path to files to be signed.
+  /**
+   * Array of paths to files to be codesigned with `signtool.exe`.
+   */
   files: Array<string>;
 }
 
-export interface SignToolOptions extends OptionalSignToolOptions, OptionalHookOptions {
-
-}
+/**
+ * @category Utility
+ */
+export interface SignToolOptions extends OptionalSignToolOptions, OptionalHookOptions {}
 
 export interface InternalSignOptions extends SignOptionsForFiles {}
 
 export interface InternalSignToolOptions extends OptionalSignToolOptions, OptionalHookOptions {
-  certificateFile?: string;
-  certificatePassword?: string;
   signToolPath: string;
   timestampServer: string;
   files: Array<string>;
@@ -35,42 +55,90 @@ export interface InternalSignToolOptions extends OptionalSignToolOptions, Option
   appendSignature?: boolean;
 }
 
+/**
+ * @category Utility
+ */
 export interface OptionalSignToolOptions {
-  // Path to a .pfx code signing certificate. Will use
-  // process.env.WINDOWS_CERTIFICATE_FILE if not provided
+  /**
+   * Path to a `.pfx` code signing certificate.
+   * Will use `process.env.WINDOWS_CERTIFICATE_FILE` if this option is not provided.
+   */
   certificateFile?: string;
-  // Password to said certificate. If you don't provide this,
-  // you need to provide a `signWithParams` option. Will use
-  // process.env.WINDOWS_CERTIFICATE_PASSWORD if not provided
+  /**
+   * Password to {@link certificateFile}. If you don't provide this,
+   * you need to provide the {@link signWithParams} option.
+   * Will use `process.env.WINDOWS_CERTIFICATE_PASSWORD` if this option is not provided.
+   */
   certificatePassword?: string;
-  // Path to a timestamp server. Defaults to http://timestamp.digicert.com
+  /**
+   * Path to a timestamp server.
+   * Will use `process.env.WINDOWS_TIMESTAMP_SERVER` if this option is not provided.
+   *
+   * @defaultValue http://timestamp.digicert.com
+   */
   timestampServer?: string;
-  // Description of the signed content. Will be passed to signtool.exe as /d
+  /**
+   * Description of the signed content. Will be passed to `signtool.exe` as `/d`.
+   */
   description?: string;
-  // URL of the signed content. Will be passed to signtool.exe as /du
+  /**
+   * URL for the expanded description of the signed content. Will be passed to `signtool.exe` as `/du`.
+   */
   website?: string;
-  // Path to signtool.exe. Will use vendor/signtool.exe if not provided
+  /**
+   * Path to the `signtool.exe` used to sign. Will use `vendor/signtool.exe` if not provided.
+   */
   signToolPath?: string;
-  // Additional parameters to pass to signtool.exe.
+  /**
+   * Additional parameters to pass to `signtool.exe`.
+   *
+   * @see Microsoft's {@link https://learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe SignTool.exe documentation}
+   */
   signWithParams?: string | Array<string>;
-  // Enable debug logging
+  /**
+   * Enables debug logging.
+   *
+   * @defaultValue false
+   */
   debug?: boolean;
-  // Automatically select the best signing certificate, passed as
-  // /a to signtool.exe, on by default
+  /**
+   * Automatically selects the best signing certificate according to SignTool. Will be passed to `signtool.exe` as `/a`.
+   *
+   * @defaultValue true
+   */
   automaticallySelectCertificate?: boolean;
-  // Should we sign JavaScript files? Defaults to false
-  signJavaScript?: boolean
+  /**
+   * Whether or not to sign JavaScript files.
+   *
+   * @defaultValue false
+   */
+  signJavaScript?: boolean;
 }
 
+/**
+ * Custom function that is called sequentially for each file that needs to be signed.
+ *
+ * @param fileToSign Absolute path to the file to sign
+ *
+ * @category Utility
+ */
 export type HookFunction = (fileToSign: string) => void | Promise<void>;
 
+/**
+ * @category Utility
+ */
 export interface OptionalHookOptions {
-  // A hook function called for each file that needs
-  // to be signed.
+  /**
+   * A hook function called for each file that needs to be signed.
+   * Use this for full control over your app's signing logic.
+   * `@electron/windows-sign` will not attempt to sign with SignTool if a custom hook is detected.
+   */
   hookFunction?: HookFunction;
-  // A path to a JavaScript file, exporting a single
-  // function that will be called for each file that
-  // needs to be signed.
+  /**
+   * A path to a JavaScript file, exporting a single function that will be called for each file that needs to be signed.
+   * Use this for full control over your app's signing logic.
+   * `@electron/windows-sign` will not attempt to sign with SignTool if a custom hook is detected.
+   */
   hookModulePath?: string;
 }
 

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://typedoc.org/schema.json",
+	"entryPoints": ["src/index.ts"],
+	"excludeInternal": true,
+	"navigation": true
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -398,6 +398,11 @@ ansi-regex@^5.0.1:
   resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
   integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
 
+ansi-sequence-parser@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/ansi-sequence-parser/-/ansi-sequence-parser-1.1.1.tgz#e0aa1cdcbc8f8bb0b5bca625aac41f5f056973cf"
+  integrity sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==
+
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz"
@@ -570,6 +575,13 @@ brace-expansion@^1.1.7:
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.1.tgz#1edc459e0f0c548486ecf9fc99f2221364b9a0ae"
+  integrity sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==
+  dependencies:
+    balanced-match "^1.0.0"
 
 braces@^3.0.1:
   version "3.0.2"
@@ -2083,6 +2095,11 @@ json5@^1.0.2:
   dependencies:
     minimist "^1.2.0"
 
+jsonc-parser@^3.2.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.1.tgz#031904571ccf929d7670ee8c547545081cb37f1a"
+  integrity sha512-AilxAyFOAcK5wA1+LeaySVBrHsGQvUFCDWXKpZjzaL0PqW+xfBOttn8GNtWKFWqneyMZj41MWF9Kl6iPWLwgOA==
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz"
@@ -2192,6 +2209,16 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lunr@^2.3.9:
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/lunr/-/lunr-2.3.9.tgz#18b123142832337dd6e964df1a5a7707b25d35e1"
+  integrity sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==
+
+marked@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.3.0.tgz#796362821b019f734054582038b116481b456cf3"
+  integrity sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==
+
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
@@ -2216,6 +2243,13 @@ min-indent@^1.0.0:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@^9.0.3:
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
+  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
+  dependencies:
+    brace-expansion "^2.0.1"
 
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.7"
@@ -2788,6 +2822,16 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+shiki@^0.14.7:
+  version "0.14.7"
+  resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.14.7.tgz#c3c9e1853e9737845f1d2ef81b31bcfb07056d4e"
+  integrity sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==
+  dependencies:
+    ansi-sequence-parser "^1.1.0"
+    jsonc-parser "^3.2.0"
+    vscode-oniguruma "^1.7.0"
+    vscode-textmate "^8.0.0"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz"
@@ -3118,6 +3162,16 @@ typed-array-length@^1.0.4:
     for-each "^0.3.3"
     is-typed-array "^1.1.9"
 
+typedoc@~0.25.13:
+  version "0.25.13"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.25.13.tgz#9a98819e3b2d155a6d78589b46fa4c03768f0922"
+  integrity sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==
+  dependencies:
+    lunr "^2.3.9"
+    marked "^4.3.0"
+    minimatch "^9.0.3"
+    shiki "^0.14.7"
+
 typescript@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz"
@@ -3177,6 +3231,16 @@ version-guard@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/version-guard/-/version-guard-1.1.1.tgz"
   integrity sha512-MGQLX89UxmYHgDvcXyjBI0cbmoW+t/dANDppNPrno64rYr8nH4SHSuElQuSYdXGEs0mUzdQe1BY+FhVPNsAmJQ==
+
+vscode-oniguruma@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz#439bfad8fe71abd7798338d1cd3dc53a8beea94b"
+  integrity sha512-L9WMGRfrjOhgHSdOYgCt/yRMsXzLDJSL7BPrOZt73gU0iWO4mpqzqQzOz5srxqTvMBaR0XZTSrVWo4j55Rc6cA==
+
+vscode-textmate@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/vscode-textmate/-/vscode-textmate-8.0.0.tgz#2c7a3b1163ef0441097e0b5d6389cd5504b59e5d"
+  integrity sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
* Converts type and interface comments to use multiline comments so they can be picked up by Intellisense.
* Link between types and to external documentation whenever possible.
* Exports a few extra types that are referenced within things that are already exported.
* Adds a TypeDoc API documentation website.

Website preview: https://erickzhao.github.io/windows-sign/