### PR TITLE
feat: signWithHook supports one-time invocation.

### DIFF
--- a/src/sign-with-hook.ts
+++ b/src/sign-with-hook.ts
@@ -37,11 +37,19 @@ function getHookFunction(options: InternalHookOptions): HookFunction {
 export async function signWithHook(options: InternalSignOptions) {
   hookFunction = getHookFunction(options);
 
-  for (const file of options.files) {
+  if (options.noIterateFiles) {
     try {
-      await hookFunction(file);
+      await hookFunction(options);
     } catch (error) {
-      log(`Error signing ${file}`, error);
+      log('Sign with hook failed.', error);
+    }
+  } else {
+    for (const file of options.files) {
+      try {
+        await hookFunction(file);
+      } catch (error) {
+        log(`Error signing ${file}`, error);
+      }
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,14 +115,24 @@ export interface OptionalSignToolOptions {
   signJavaScript?: boolean;
 }
 
-/**
- * Custom function that is called sequentially for each file that needs to be signed.
- *
- * @param fileToSign Absolute path to the file to sign
- *
- * @category Utility
- */
-export type HookFunction = (fileToSign: string) => void | Promise<void>;
+export type HookFunction = {
+  /**
+   * Custom function that is called sequentially for each file that needs to be signed.
+   *
+   * @param fileToSign Absolute path to the file to sign
+   *
+   * @category Utility
+   */
+  (fileToSign: string) : void | Promise<void>
+  /**
+   * Custom function that is called once，passed origin sign options.
+   *
+   * @param options Origin sign options with filtered files.
+   *
+   * @category Utility
+   */
+  (options: InternalSignOptions) : void | Promise<void>
+}
 
 /**
  * @category Utility
@@ -140,6 +150,11 @@ export interface OptionalHookOptions {
    * `@electron/windows-sign` will not attempt to sign with SignTool if a custom hook is detected.
    */
   hookModulePath?: string;
+  /**
+   * Do not iterate files which need to be signed. If true,
+   * it will call hookFunction one-time with origin sign options.
+   */
+  noIterateFiles?: boolean;
 }
 
 export interface InternalHookOptions extends OptionalHookOptions {

--- a/test/sign-with-hook.spec.ts
+++ b/test/sign-with-hook.spec.ts
@@ -7,13 +7,12 @@ describe('sign with hook', async () => {
   it('should call a hook function', async () => {
     let hookCalled = false;
 
-    const hookFunction = (filePath: string) => {
+    const hookFunction = (filePath) => {
       assert.equal(filePath, 'my/fake/file');
       hookCalled = true;
     };
 
     await signWithHook({
-      appDirectory: '',
       files: ['my/fake/file'],
       hookFunction
     });
@@ -24,7 +23,7 @@ describe('sign with hook', async () => {
   it('should call a async hook function', async () => {
     let hookCalled = false;
 
-    const hookFunction = async (filePath: string) => {
+    const hookFunction = async (filePath) => {
       assert.equal(filePath, 'my/fake/file');
 
       return new Promise<void>((resolve) => {
@@ -36,7 +35,6 @@ describe('sign with hook', async () => {
     };
 
     await signWithHook({
-      appDirectory: '',
       files: ['my/fake/file'],
       hookFunction
     });
@@ -47,11 +45,26 @@ describe('sign with hook', async () => {
   it('should call a hook module', async () => {
     const fakeFile = `my/fake/file/${Date.now()}`;
     await signWithHook({
-      appDirectory: '',
       files: [fakeFile],
       hookModulePath: './test/fixtures/hook-module.js'
     });
 
     assert.strictEqual(process.env.HOOK_MODULE_CALLED_WITH_FILE, fakeFile);
+  });
+
+  it('should call a hook function once when noIterateFiles is true', async () => {
+    const functionCalled: string[] = [];
+
+    const hookFunction = (options) => {
+      functionCalled.push(options.files);
+    };
+
+    await signWithHook({
+      files: ['my/fake/file1', 'my/fake/file2'],
+      hookFunction,
+      noIterateFiles: true
+    });
+
+    assert.deepStrictEqual(functionCalled, [['my/fake/file1', 'my/fake/file2']]);
   });
 });


### PR DESCRIPTION
This pull request adds a parameter: `noIterateFiles`.

In my company, a single Windows certificate is used for signing multiple Electron applications, so we want to centralize the signing capability onto one device to save on certificate purchase costs.

Currently, I plan to modify the signing process on each CI (Continuous Integration) device using a `hookFunction`. This involves compressing all DLLs that need to be signed into a ZIP file, uploading it to a dedicated signing machine, downloading the signed artifacts after signing is complete, and completing the remote signing process. This ensures that the signing machine does not need to perform any additional tasks, such as packaging frontend artifacts.

However, the original logic of `signWithHooks` would call the `hookFunction` multiple times, which would be disastrous in my plan as it would lead to multiple upload and download processes. Therefore, I added a parameter to control this logic. If this parameter is not passed, no one's logic will be affected because it is forward-compatible.

Additionally, some parameters causing type errors were removed from the unit test section.