### PR TITLE
fix: sea error handling

### DIFF
--- a/src/sea.ts
+++ b/src/sea.ts
@@ -90,8 +90,7 @@ function main() {
       throw new Error(stderr);
     }
   } catch (error) {
-    process.exitCode = 1;
-    throw new Error(error);
+    process.exit(1);
   }
 }
 

--- a/src/sea.ts
+++ b/src/sea.ts
@@ -90,6 +90,8 @@ function main() {
       throw new Error(stderr);
     }
   } catch (error) {
+    // Do not rethrow the error or write it to stdout/stderr. Then the process won't terminate.
+    // See: https://github.com/electron/windows-sign/pull/48
     process.exit(1);
   }
 }


### PR DESCRIPTION
`throw new Error(error)` does not terminate the SEA process when used via Forge's `MakerSquirrel`.

I had a case where due to a misconfiguration an error was thrown in the `try` block and subsequently caught in the `catch` block that this PR modifies. The process didn't exit upon reaching `throw new Error(error)`. Instead, it kept running indefinitely. (This reproduced reliably every time I ran it.)

As a result, my `electron-forge make` command kept running indefinitely (without succeeding or failing) because `squirrel.exe --releasify` thought signing (via the SEA) was still ongoing.

My guess is that it has something to do with stdout/stderr. If I log the error in the `catch` block using `console.log` or `console.error`, the process also does not terminate.

The issue was hard to debug. It took me ~4 hours to figure out. Hope this will save someone else from having to do the same.