### PR TITLE
feat: support bypass default signtool args

### DIFF
--- a/src/sign-with-signtool.ts
+++ b/src/sign-with-signtool.ts
@@ -11,51 +11,53 @@ function getSigntoolArgs(options: InternalSignToolOptions) {
   // https://learn.microsoft.com/en-us/dotnet/framework/tools/signtool-exe
   const { certificateFile, certificatePassword, hash, timestampServer } = options;
   const args = ['sign'];
-
-  // Automatically select cert
-  if (options.automaticallySelectCertificate) {
-    args.push('/a');
-  }
-
-  // Dual-sign
-  if (options.appendSignature) {
-    args.push('/as');
-  }
-
-  // Timestamp
-  if (hash === HASHES.sha256) {
-    args.push('/tr', timestampServer);
-    args.push('/td', hash);
-  } else {
-    args.push('/t', timestampServer);
-  }
-
-  // Certificate file
-  if (certificateFile) {
-    args.push('/f', path.resolve(certificateFile));
-  }
-
-  // Certificate password
-  if (certificatePassword) {
-    args.push('/p', certificatePassword);
-  }
-
-  // Hash
-  args.push('/fd', hash);
-
-  // Description
-  if (options.description) {
-    args.push('/d', options.description);
-  }
-
-  // Website
-  if (options.website) {
-    args.push('/du', options.website);
-  }
-
-  // Debug
-  if (options.debug) {
-    args.push('/debug');
+  if(!options.noDefaultParams)
+  {
+    // Automatically select cert
+    if (options.automaticallySelectCertificate) {
+      args.push('/a');
+    }
+  
+    // Dual-sign
+    if (options.appendSignature) {
+      args.push('/as');
+    }
+  
+    // Timestamp
+    if (hash === HASHES.sha256) {
+      args.push('/tr', timestampServer);
+      args.push('/td', hash);
+    } else {
+      args.push('/t', timestampServer);
+    }
+  
+    // Certificate file
+    if (certificateFile) {
+      args.push('/f', path.resolve(certificateFile));
+    }
+  
+    // Certificate password
+    if (certificatePassword) {
+      args.push('/p', certificatePassword);
+    }
+  
+    // Hash
+    args.push('/fd', hash);
+  
+    // Description
+    if (options.description) {
+      args.push('/d', options.description);
+    }
+  
+    // Website
+    if (options.website) {
+      args.push('/du', options.website);
+    }
+  
+    // Debug
+    if (options.debug) {
+      args.push('/debug');
+    }
   }
 
   if (options.signWithParams) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,13 @@ export interface OptionalSignToolOptions {
    * Hash algorithms to use for signing.
    */
   hashes?: HASHES[];
+  /**
+   * Do not populate parameters being passed to `signtool.exe`. Rely completely on {@link signWithParams}.
+   * 
+   * @defaultValue false
+   */
+  noDefaultParams?: boolean,
+
 }
 
 /**


### PR DESCRIPTION
I found the default args populated for signtool prevent me from using https://github.com/vcsjones/AzureSignTool as my signtool.exe. An option to bypass the default parameters an let me fill my parameter by myself with signWithParams would allow to use AzureSignTool correctly.