### PR TITLE
build: rename docs script to build:docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "scripts": {
     "build": "tsc",
-    "docs": "npx typedoc",
+    "build:docs": "npx typedoc",
     "lint": "prettier --check src test && eslint --ext .ts,.mjs src bin test",
     "test": "globstar -- node --import tsx --test \"test/**/*.spec.ts\"",
     "prepublishOnly": "yarn build",


### PR DESCRIPTION
Fast follow-up to #59. The generic publish docs workflow we've been copying and pasting around expects this to be `build:docs`, so rename it to be consistent with our other repos.