### PR TITLE
fix: leave binary files as-is in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* eol=crlf
+* text=auto eol=crlf


### PR DESCRIPTION
This was forcing the vendored binary to be modified by git which broke it.