### PR TITLE
fix: `SEA_MAIN` only supports CommonJS

### DIFF
--- a/src/sea.ts
+++ b/src/sea.ts
@@ -56,11 +56,12 @@ const FILENAMES = {
 };
 
 const SEA_MAIN_SCRIPT = `
-import { spawnSync } from 'node:child_process';
 
 const bin = "%PATH_TO_BIN%";
 const script = "%PATH_TO_SCRIPT%";
 const options = %WINDOWS_SIGN_OPTIONS%
+
+const { spawnSync } = require('node:child_process');
 
 function main() {
   console.log("@electron/windows-sign sea");


### PR DESCRIPTION
```
PS C:\Users\circleci\project> .\node_modules\electron-winstaller\vendor\signtool.exe --version
(node:4288) Warning: Failed to load the ES module: sea.js. Make sure to set "type": "module" in the nearest package.json file or use the .mjs extension.
(Use `signtool --trace-warnings ...` to show where the warning was created)
sea.js:2
import { spawnSync } from 'node:child_process';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at embedderRunCjs (node:internal/main/embedding:60:7)

Node.js v22.17.1
```

> The single executable application feature currently only supports running a single embedded script using the [CommonJS](https://github.com/nodejs/node/blob/main/doc/api/modules.md#modules-commonjs-modules) module system.