### PR TITLE
fix: revert SEA script back to CJS

### DIFF
--- a/src/sea.ts
+++ b/src/sea.ts
@@ -56,11 +56,11 @@ const FILENAMES = {
 };
 
 const SEA_MAIN_SCRIPT = `
-import { spawnSync } from 'node:child_process';
-
 const bin = "%PATH_TO_BIN%";
 const script = "%PATH_TO_SCRIPT%";
 const options = %WINDOWS_SIGN_OPTIONS%
+
+const { spawnSync } = require('child_process');
 
 function main() {
   console.log("@electron/windows-sign sea");


### PR DESCRIPTION
Incidental change from #59, but SEAs have to be be CJS still according to the [Node.js docs](https://nodejs.org/api/single-executable-applications.html#single-executable-applications):

> The single executable application feature currently only supports running a single embedded script using the [CommonJS](https://nodejs.org/api/modules.html#modules-commonjs-modules) module system.

