### PR TITLE
ci: test on arm64 Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,10 @@ jobs:
       matrix:
         node-version:
           - '22.12.x'
-    runs-on: windows-latest
+        os:
+          - windows-latest
+          - windows-11-arm
+    runs-on: "${{ matrix.os }}"
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
I don't think there's any meaningful difference in the tests across architectures here at the moment, but good to test on both architectures regardless, especially if we add more tests in the future for stuff like creating the SEA.