### PR TITLE
fix: parsing `signWithParams` with double quotes

### DIFF
--- a/src/sign-with-signtool.ts
+++ b/src/sign-with-signtool.ts
@@ -62,7 +62,11 @@ function getSigntoolArgs(options: InternalSignToolOptions) {
       extraArgs.push(...options.signWithParams);
     } else {
       // Split up at spaces and doublequotes
-      extraArgs.push(...(options.signWithParams.match(/(?:[^\s"]+|"[^"]*")+/g) as Array<string>));
+      extraArgs.push(
+        ...[...options.signWithParams.matchAll(/(?:([^\s"]+)|"([^"]*)")+/g)].map(
+          (matched) => matched[1] || matched[2],
+        ),
+      );
     }
 
     log('Parsed signWithParams as:', extraArgs);


### PR DESCRIPTION
Fixes https://github.com/electron/windows-sign/issues/45.

Solution by @ShGKme (thank you!). I only raised a PR with the change as I think it's valuable to spread the fix. Especially because more and more people will switch to Cloud HSM providers, they will run into the problem where `/csp` won't be properly parsed and `signtool` will fail (silently).