### PR TITLE
chore: force LF line endings for yarn.lock

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 * text=auto eol=crlf
 .husky/* text=auto eol=lf
+yarn.lock text eol=lf


### PR DESCRIPTION
This should stop Dependabot PRs from being huge diffs.