### PR TITLE
fix: propagate errors from custom hook

### DIFF
--- a/src/sign-with-hook.ts
+++ b/src/sign-with-hook.ts
@@ -1,7 +1,6 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { HookFunction, InternalHookOptions, InternalSignOptions } from './types.js';
-import { log } from './utils/log.js';
 
 let hookFunction: HookFunction;
 
@@ -41,10 +40,6 @@ export async function signWithHook(options: InternalSignOptions) {
   hookFunction = await getHookFunction(options);
 
   for (const file of options.files) {
-    try {
-      await hookFunction(file);
-    } catch (error) {
-      log(`Error signing ${file}`, error);
-    }
+    await hookFunction(file);
   }
 }

--- a/test/fixtures/hook-module-error.js
+++ b/test/fixtures/hook-module-error.js
@@ -1,0 +1,3 @@
+export default function (file) {
+  throw new Error(`failed to sign ${file}`);
+}

--- a/test/sign-with-hook.spec.ts
+++ b/test/sign-with-hook.spec.ts
@@ -51,4 +51,43 @@ void describe('sign with hook', async () => {
 
     assert.strictEqual(process.env.HOOK_MODULE_CALLED_WITH_FILE, fakeFile);
   });
+
+  void it('should throw an error from a hook function', async () => {
+    const hookFunction = (filePath: string) => {
+      throw new Error(`failed to sign ${filePath}`);
+    };
+
+    await assert.rejects(
+      signWithHook({
+        files: ['my/fake/file'],
+        hookFunction,
+      }),
+      /failed to sign my\/fake\/file/,
+    );
+  });
+
+  void it('should throw an error from an async hook function', async () => {
+    const hookFunction = async (filePath: string) => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      throw new Error(`failed to sign ${filePath}`);
+    };
+
+    await assert.rejects(
+      signWithHook({
+        files: ['my/fake/file'],
+        hookFunction,
+      }),
+      /failed to sign my\/fake\/file/,
+    );
+  });
+
+  void it('should throw an error from a hook module', async () => {
+    await assert.rejects(
+      signWithHook({
+        files: ['my/fake/file'],
+        hookModulePath: './test/fixtures/hook-module-error.js',
+      }),
+      /failed to sign my\/fake\/file/,
+    );
+  });
 });


### PR DESCRIPTION
This fixes #49, which made it impossible to detect whether a custom hook function or module had failed.

I'm not sure if it's worth adding extra context to the error here, but it seems fine to just pass through the error as is since it comes directly from code provided by the user.

Note that this brings `signWithHook` into consistency with `signWithSignTool`, which already throws various errors when things go wrong, so it doesn't really change the contract of the overall `sign` function. It's possible that users may be expecting the existing behavior and working around it by checking out-of-band whether artifacts actually got signed, but it's kind of hard to picture.